### PR TITLE
Fix broken links in Ethernet.md

### DIFF
--- a/Ethernet.md
+++ b/Ethernet.md
@@ -10,7 +10,7 @@ U1B2)
 
 ## ICS1893BF
 
-[Datasheet](http://www.dz863.com/downloadpdf-nalovdjulo-ICS1893BKLFT.pdf)
+[Datasheet](https://www.idt.com/document/dst/1893bfbk-datasheet)
 
 Comes from Integrated Circuit Systems, Inc.
 
@@ -19,7 +19,7 @@ Comes from Integrated Circuit Systems, Inc.
 
 ## BCM5241
 
-[Datasheet](http://www.datasheetcatalog.org/datasheet2/6/0rph5whyftf3gi8c6lyy5xp2037y.pdf)
+[Datasheet](https://docs.broadcom.com/docs/12358209)
 
 Comes from Integrated Circuit Systems, Inc.
 


### PR DESCRIPTION
ICS chip pdf was a dead link and for some reason BCM datasheet link was to the ICS datasheet. Not sure if this is significant but the link I provided is to the IDT website and the ICS chip pdf has IDT's document headers instead of ICS, and the final "Ordering Information" page has been changed, and the IDT PDF has working links, other than these I do not believe there are any differences in the documents.