### PR TITLE
Add lost SMC commands to SMC.md and fix formatting

### DIFF
--- a/docs/SMC.md
+++ b/docs/SMC.md
@@ -1,5 +1,5 @@
 The **System Management Controller (SMC)** is an
-[8051/8052](8051/8052 "wikilink") core inside the
+[8051/8052](8051_8052 "wikilink") core inside the
 [Southbridge](Southbridge "wikilink"). It manages the power sequencing,
 and is always active when the Xbox 360 has (standby or full) power
 applied. It controls the frontpanel, has a Realtime clock, decodes IR,
@@ -19,15 +19,17 @@ first byte.
 
 <code>
 
-`void smc_send(void *msg)`
-`{`
-`      while (!(readl(0xea001084) & 4))    // wait for FIFO ready`
-`              cpu_relax();`
+```
+void smc_send(void *msg)
+{
+      while (!(readl(0xea001084) & 4))    // wait for FIFO ready
+              cpu_relax();
 
-`      writel(4, 0xea001084);              // start message`
-`      writesl(0xea001080, msg, 4);        // send 16 bytes`
-`      writel(0, 0xea001084);              // end message`
-`}`
+      writel(4, 0xea001084);              // start message
+      writesl(0xea001080, msg, 4);        // send 16 bytes
+      writel(0, 0xea001084);              // end message
+}
+```
 
 </code>
 
@@ -39,46 +41,56 @@ byte).
 
 <code>
 
-`int smc_read_reply(void *msg)`
-`{`
-`      if (!(readl(0xea001094) & 4))       // do we have a reply?`
-`              return 0;`
+```
+int smc_read_reply(void *msg)
+{
+      if (!(readl(0xea001094) & 4))       // do we have a reply?
+              return 0;
 
-`      writel(4, 0xea001094);              // start reply`
-`      readsl(0xea001090, msg, 4);         // read 16 bytes`
-`      writel(0, 0xea001094);              // end reply`
-`      return 1;`
-`}`
+      writel(4, 0xea001094);              // start reply
+      readsl(0xea001090, msg, 4);         // read 16 bytes
+      writel(0, 0xea001094);              // end reply
+      return 1;
+}
+```
 
 </code>
 
 ## Command Messages
 
-| ID                     | Len      | Example | Purpose                                                    |
-| ---------------------- | -------- | ------- | ---------------------------------------------------------- |
-| \[\[SMC_Command_0x82 | 0x82\]\] | 2-3     | "\\x82\\0x04\\0x31\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" |
-| \[\[SMC_Command_0x8c | 0x8c\]\] | 3       | "\\x8c\\0x01\\0x00\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" |
+| ID                                   | Len     | Example                                                    | Purpose                    |
+| ------------------------------------ | ------- | ---------------------------------------------------------- | -------------------------- |
+| [0x82](SMC_Command_0x82 "wikilink")  | 2-3     | "\\x82\\0x04\\0x31\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | set standby/power          |
+| 0x85                                 | ?       | ?                                                          | set real time clock        |
+| 0x88                                 | ?       | ?                                                          | set fan algorithm          |
+| 0x89                                 | ?       | ?                                                          | set fan speed (cpu/gpu?)   |
+| 0x8b                                 | ?       | "\\x8b\\0x62\\0x00\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | set dvd tray               |
+| 0x8c                                 | 3       | "\\x8c\\0x01\\0x00\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | set power led              |
+| 0x8d                                 | 2       | "\\x8d\\0x01\\0x00\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | set audio mute             |
+| 0x94                                 | ?       | ?                                                          | set fan speed (cpu/gpu?)   |
+| 0x95                                 | ?       | ?                                                          | set ir address             |
+| 0x98                                 | 1       | "\\x98\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0"       | set dvd tray secure        |
+| 0x99                                 | 3       | "\\x99\\0x01\\0x0f\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | set ring of light          |
+| 0x9a                                 | ?       | ?                                                          | set rtc wake               |
 
 ## Query Messages
 
-| ID                     | Len      | Example Query | Example Reply                                        | Purpose                      |
-| ---------------------- | -------- | ------------- | ---------------------------------------------------- | ---------------------------- |
-| \[\[SMC_Command_0x01 | 0x01\]\] | 1:6           | "\\x01\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `01 12 00 00 00 00`          |
-| \[\[SMC_Command_0x04 | 0x04\]\] | 1:11          | "\\x04\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `04 602f 212223 01 00000000` |
-| \[\[SMC_Command_0x07 | 0x07\]\] | 1:10          | "\\x07\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `07ff 241b 2fa4 2cfa 262c`   |
-| \[\[SMC_Command_0x0a | 0x0a\]\] | 1:2           | "\\x0a\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `0a 60`                      |
-| \[\[SMC_Command_0x0f | 0x0f\]\] | 1:2           | "\\x0f\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `0f 54`                      |
-| \[\[SMC_Command_0x11 | 0x11\]\] | 6:2           | "\\x11\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `11 02`                      |
-| \[\[SMC_Command_0x12 | 0x12\]\] | 1:6           | "\\x12\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `1241 0203 0000`             |
-| \[\[SMC_Command_0x16 | 0x16\]\] | 1:2           | "\\x16\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `16 0f`                      |
-| \[\[SMC_Command_0x17 | 0x17\]\] | 1:2           | "\\x17\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `17 00`                      |
-|  |
+| ID                                   | Len      | Example Query                                        | Example Reply                | Purpose                      |
+| ------------------------------------ | -------- | ---------------------------------------------------- | ---------------------------- | ---------------------------- |
+| [0x01](SMC_Command_0x01 "wikilink")  | 1:6      | "\\x01\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `01 12 00 00 00 00`          | power on type                |
+| 0x04                                 | 1:11     | "\\x04\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `04 602f 212223 01 00000000` | real time clock              |
+| 0x07                                 | 1:10     | "\\x07\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `07ff 241b 2fa4 2cfa 262c`   | read temps                   |
+| 0x0a                                 | 1:2      | "\\x0a\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `0a 60`                      | request tray state           |
+| 0x0f                                 | 1:2      | "\\x0f\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `0f 54`                      | request AV pack type         |
+| 0x11                                 | 6:2      | "\\x11\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `11 02`                      | read ana                     |
+| 0x12                                 | 1:6      | "\\x12\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `1241 0203 0000`             | request SMC version          |
+| 0x16                                 | 1:2      | "\\x16\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `16 0f`                      | query IR address             |
+| 0x17                                 | 1:2      | "\\x17\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0" | `17 00`                      | query tilt sensor            |
 
 ## Event Messages
 
-| ID                     | Len      | Example Message | Purpose |
-| ---------------------- | -------- | --------------- | ------- |
-| \[\[SMC_Command_0x83 | 0x83\]\] | 2               | `83 64` |
-|  |
+| ID   | Len   | Example Message | Purpose   |
+| ---- | ----- | --------------- | --------- |
+| 0x83 | 2     | `83 64`         | SMC event |
 
 [Category:Xbox360_Hardware](Category_Xbox360_Hardware)


### PR DESCRIPTION
Sources:
[https://op-co.de/xbox360/smc.c](https://op-co.de/xbox360/smc.c)
[Wayback of SMC on free60.org](https://web.archive.org/web/20180318232425/http://www.free60.org/wiki/SMC)