### PR TITLE
Fix typo in BB block size in NAND_Bad_Blocks.md

### DIFF
--- a/docs/NAND_Bad_Blocks.md
+++ b/docs/NAND_Bad_Blocks.md
@@ -2,7 +2,7 @@
 
 A block is the smallest logically addressable unit of data that a
 specified device can transfer in an input/output operation. For XBOX
-360s that is either 16KB or 132KB.
+360s that is either 16KB or 128KB.
 
 ## What is a BAD BLOCK?
 


### PR DESCRIPTION
Big block block size is 128KB according to later in this page and NAND.md, not 132KB.