### PR TITLE
Fix intra-wiki links within File Formats section

### DIFF
--- a/docs/System-Software/Formats/GPD.md
+++ b/docs/System-Software/Formats/GPD.md
@@ -355,4 +355,4 @@ IDs in Sync List between last and next are
 pushed
 //confirm?
 
-[System Software](System_Software)
+[System Software](/System-Software)

--- a/docs/System-Software/Formats/PEC.md
+++ b/docs/System-Software/Formats/PEC.md
@@ -1,5 +1,5 @@
 **PEC** (Profile Embedded Content) files are used by the Xbox 360 as an
-additional layer of security on profiles. Certain [GPD](GPD)
+additional layer of security on profiles. Certain [GPD](../GPD)
 files are relocated inside the PEC file. The PEC file stores information
 on avatar clothes/items, and is just another STFS package. With this
 said you must properly rehash and resign the PEC file to avoid the Xbox
@@ -23,16 +23,16 @@ below).
 # Notes
 
 The Console ID at 0x275 must match the Console ID located in the
-[Console Security Certificate](Console_Security_Certificate),
+[Console Security Certificate](../../Console_Security_Certificate),
 otherwise the Xbox 360 will see it as a corrupted file.
 
 The signature located in the [Console Security
-Certificate](Console_Security_Certificate) is signed using
+Certificate](../../Console_Security_Certificate) is signed using
 the hash at location 0x228. (SHA1 hash from 0x23C - 0x1000)
 
 From 0x1000 the rest of the file is the standard block portion of
-[STFS](STFS), with data block 0 starting at 0x3000, and hash
+[STFS](../STFS), with data block 0 starting at 0x3000, and hash
 table 0 at 0x1000/0x2000. The PEC file always has 2 hash tables (type 1
 package).
 
-[System Software](System_Software)
+[System Software](/System_Software)

--- a/docs/System-Software/Formats/PEC.md
+++ b/docs/System-Software/Formats/PEC.md
@@ -35,4 +35,4 @@ From 0x1000 the rest of the file is the standard block portion of
 table 0 at 0x1000/0x2000. The PEC file always has 2 hash tables (type 1
 package).
 
-[System Software](/System_Software)
+[System Software](/System-Software)

--- a/docs/System-Software/Formats/SPA.md
+++ b/docs/System-Software/Formats/SPA.md
@@ -248,4 +248,4 @@ string.
 | 2      | 2                 | UInt16 | String Length |
 | 4      | **String Length** | String | String        |
 
-[System Software](/System_Software)
+[System Software](/System-Software)

--- a/docs/System-Software/Formats/SPA.md
+++ b/docs/System-Software/Formats/SPA.md
@@ -1,6 +1,6 @@
-**SPA** files are contained inside [XEX](XEX) files or within
-Updates or DLC. They are just a [XDBF](XDBF) file, they are
-used by the dashboard for [GPD](GPD) creation and [Xbox LIVE](Xbox_LIVE) information.
+**SPA** files are contained inside [XEX](../XEX) files or within
+Updates or DLC. They are just a [XDBF](../XDBF) file, they are
+used by the dashboard for [GPD](../GPD) creation and [Xbox LIVE](Xbox_LIVE) information.
 
 # Record Table
 
@@ -248,4 +248,4 @@ string.
 | 2      | 2                 | UInt16 | String Length |
 | 4      | **String Length** | String | String        |
 
-[System Software](System_Software)
+[System Software](/System_Software)

--- a/docs/System-Software/Formats/STFS.md
+++ b/docs/System-Software/Formats/STFS.md
@@ -507,4 +507,4 @@ internal int ComputeLevelNHashBlockNumber(int xBlock, int xLevel)
   problems with creation, some prefer to use XLAST)
 - XLAST inside the Xbox 360 SDK can create LIVE/PIRS packages, but it is illegal to share it.
 
-[System Software](/System_Software)
+[System Software](/System-Software)

--- a/docs/System-Software/Formats/STFS.md
+++ b/docs/System-Software/Formats/STFS.md
@@ -137,7 +137,7 @@ If the **Metadata Version** field is set to 2, the format is slightly changed.
 | 0x0368 | 0x4                                  | int                                     | Save Game ID                                      |
 | 0x036C | 0x5                                  | byte\[\]                                | Console ID                                        |
 | 0x0371 | 0x8                                  | byte\[\]                                | Profile ID                                        |
-| 0x0379 | 0x24                                 | [Volume Descriptor](#Volume_Descriptor) | Volume Descriptor                                 |
+| 0x0379 | 0x24                                 | [Volume Descriptor](#volume-descriptor) | Volume Descriptor                                 |
 | 0x039D | 0x4                                  | signed int                              | Data File Count                                   |
 | 0x03A1 | 0x8                                  | signed long                             | Data File Combined Size                           |
 | 0x0389 | 0x4                                  | int (STFS = 0, SVOD = 1)                | Descriptor type                                   |
@@ -251,7 +251,7 @@ Block 0 starts at 0x3000, and hash table 0 at 0x1000/0x2000.
 | 0x000  | 0x228  | Console_Security_Certificate       | Console Security Certificate     |
 | 0x228  | 0x14   | bytes                              | SHA1 hash from 0x23C-0x1000      |
 | 0x23C  | 0x8    | signed long                        | Unknown                          |
-| 0x244  | 0x24   | [Volume Descriptor](#STFS_2)       | Volume Descriptor (STFS)         |
+| 0x244  | 0x24   | [Volume Descriptor](#volume-descriptor)       | Volume Descriptor (STFS)         |
 | 0x268  | 0x4    | signed int                         | Unknown                          |
 | 0x26C  | 0x8    | bytes                              | Profile ID                       |
 | 0x274  | 0x1    | byte                               | Unknown                          |
@@ -507,4 +507,4 @@ internal int ComputeLevelNHashBlockNumber(int xBlock, int xLevel)
   problems with creation, some prefer to use XLAST)
 - XLAST inside the Xbox 360 SDK can create LIVE/PIRS packages, but it is illegal to share it.
 
-[System Software](System_Software)
+[System Software](/System_Software)

--- a/docs/System-Software/Formats/XDBF.md
+++ b/docs/System-Software/Formats/XDBF.md
@@ -1,10 +1,10 @@
 **XDBF** (**X**box **D**ata **B**ase **F**ile) files are used by the
 Xbox 360 as a generic database. It is used as the format for
-[GPD](GPD) (**G**amer **P**rofile **D**ata) and
-[SPA](SPA) (**S**tatistics, **P**resence and
+[GPD](../GPD) (**G**amer **P**rofile **D**ata) and
+[SPA](../SPA) (**S**tatistics, **P**resence and
 **A**chievements) files. SPA files are linked into an Xbox 360
 executable during compilation and are used by the dashboard to generate
-the GPD, Save Game ([STFS](STFS)) Meta-Data and Images. In
+the GPD, Save Game ([STFS](../STFS)) Meta-Data and Images. In
 the XAM the DataFile class handles all of the operations associated with
 these files.
 
@@ -89,4 +89,4 @@ entry, workout the actual length of the free space table.
 \+ 24, 24 is the length of the
 header.
 
-[System Software](System_Software)
+[System Software](/System-Software)

--- a/docs/System-Software/Formats/XEX.md
+++ b/docs/System-Software/Formats/XEX.md
@@ -304,4 +304,4 @@ XEX files are the default executable format.
     0x184...0x184+(IDC*24)  ImageData0[8], ImageData1[8], ImageData2[8]
     </nowiki>
 
-[System Software](System_Software)
+[System Software](/System-Software)


### PR DESCRIPTION
There is still a link in SPA.md to a missing Xbox_LIVE page.