### PR TITLE
Update IRC information, add Discord guild link

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ source venv/bin/activate
 4. Install needed python dependencies using python package manager -> pip
 
 ```sh
-pip install mkdocs mkdocs-material
+pip install mkdocs mkdocs-material mkdocs-redirects
 ```
 
 5. At this point, load up the clone repository in a text editor that has live-markdown preview function.

--- a/docs/Development/LibXenon/index.md
+++ b/docs/Development/LibXenon/index.md
@@ -32,8 +32,7 @@ already! - See bottom of [Xenon Toolchain](../Compiling_the_Toolchain)-page if i
 ## Support
 
 **libXenon** (or **devkitxenon**) stuff is best discussed in
-\#free60-noos on the OFTC IRC network , <irc://irc.oftc.net/free60-noos>
-or in \#libXenon on EFnet IRC, <irc://irc.efnet.fr/libXenon>
+the [IRC](/Support/IRC/) or [Discord](/Support/Discord/)
 
 ## Sample Code
 

--- a/docs/Hacks/NAND_Reading.md
+++ b/docs/Hacks/NAND_Reading.md
@@ -15,8 +15,6 @@ There are guides to dump via USB, but compared to this it's quite
 expensive and easily found with a search. Maybe someone will add one
 later on.
 
-If you're facing any problems, feel free to ask in \#free60 on OFTC. :)
-
 Moreover thanks to tmbinc, Tiros, Redline and all else involved (feel
 free to add their names) for their great work! :)
 

--- a/docs/Support/Discord.md
+++ b/docs/Support/Discord.md
@@ -1,0 +1,6 @@
+Join us in the Free60 Project Discord guild at
+[https://discord.gg/KvMB4HzHym](https://discord.gg/KvMB4HzHym)
+to discuss the Free60 project, the Linux kernel ports, LibXenon and LibXenon
+homebrew, and XeLL Reloaded.
+
+Rules are available in the \#rules-and-guidelines channel.

--- a/docs/Support/Help.md
+++ b/docs/Support/Help.md
@@ -1,13 +1,9 @@
-## IRC
+## IRC/Discord
 
-Server ⇒ <font color="purple">irc.oftc.net</font>(irc.oftc.net)
-Channel ⇒ \#free60 ; \#free60-chat ; \#free60-dev
-or if theres nobody replying try:
+For real-time chat, for either support or to help with the project, you can
+join us on [IRC](/Support/IRC/) or [Discord](/Support/Discord/).
 
-Server ⇒ <font color="purple">irc.efnet.nl</font>
-Channel ⇒ \#libxenon
-
-\== Want to Help? ==
+## Want to Help?
 
 Here is what you can do to help this project:
 

--- a/docs/Support/IRC.md
+++ b/docs/Support/IRC.md
@@ -1,22 +1,15 @@
-Join us on the Free60 IRC channel at <irc://irc.oftc.net/free60-chat>
-(server irc.oftc.net, channel **\#free60-chat**)
+Join us in the Free60 IRC channel **\#free60** at
+[irc.libera.chat](https://libera.chat/) to discuss the Free60 project, the
+Linux kernel ports, LibXenon and LibXenon homebrew, and XeLL Reloaded.
 
-To contribute new information and speak with devs, come to
-<irc://irc.oftc.net/free60> (server irc.oftc.net, channel **\#free60**)
-
-There's also a channel for the guys on EFNET which is currently the most
-active channel of all three.
-
-Catch us in **#libxenon** on EFnet!
-
-Free60 and oftc.net are happy to facilitate the means for information
+Free60 and Libera.Chat are happy to facilitate the means for information
 gathering and dissemination. But, we have some basic guidelines we need
 you to follow.
 
 ## Guidelines
 
 We're not trying to be dictators, we just want everyone to get along.
-[OFTC](http://www.oftc.net/) is a civil network and we'd like to keep it
+[Libera](https://libera.chat/) is a civil network and we'd like to keep it
 that way.
 
 ### Basic Guidelines
@@ -40,15 +33,13 @@ that way.
 
   - \#free60 is NOT a distribution point for pirated/illegal material,
     be it software or even documentation. We have zero-tolerance towards
-    any related discussion. That also goes for use ofÂ !list or other
-    such commands. You have been warned.
+    any related discussion.
 
 ### Asking Questions
 
 #### Before Asking
 
-  - Search the wiki for an answer.
-  - Search the mailing list.
+  - Search the wiki and [GitHub](https://github.com/Free60Project) for an answer.
 
 #### While Asking
 
@@ -63,31 +54,8 @@ that way.
     post that info.
   - Stick around to help others after you.
 
-### Use the right channel
-
-There are two channels in OFTC currently for public use:
-
-1.  **#free60** is for technical and development discussion, for idle chat
-    seek #free60-chat.
-2.  **#free60-chat** is for general discussion on or off topic for free60
-    and is loosely controlled.
-
-And one public channel on EFNET
-
-1.  **#libxenon** for everything from LibXenon and Linux till XeLL
-
-  - Currently neither channel is moderated ( m) though if conversations
-    get out of hand or anything of that nature we reserve the right to
-    place higher restrictions.
-  - Both channels will receive the same updates about important
-    information.
-  - You can hang out in both, but make sure you questions are for the
-    right channel.
-
 ## Conclusion
 
 Thank you for your interest in Free60, enjoy your stay!
-
-<iframe src="https://webchat.oftc.net/?channels=%23free60%2C%23free60-chat" width="647" height="400"></iframe>
 
 [Category: Support](../Category_Support)

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,14 @@
 Welcome to the archive of Free60.org Mediawiki.
 
 To submit changes:
-1. Fork the repo
+
+1. Fork [the repo](https://github.com/Free60Project/wiki)
+
 2. Make changes
+
 3. Send a Pull Request
+
+Join us on [IRC](/Support/IRC/) or [Discord](/Support/Discord/)!
 
 ## Categories
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,11 +25,11 @@ markdown_extensions:
 nav:
     - Home:
       - 'index.md'
-      - Attack: 'Support/Attack.md'
+      - IRC: 'Support/IRC.md'
+      - Discord: 'Support/Discord.md'
       - Contribute: 'Support/Contribute.md'
       - Help: 'Support/Help.md'
       - Frequently Asked Questions: 'Support/FAQ.md'
-      - IRC: 'Support/IRC.md'
       - Links: 'Support/Links.md'
     - Hacks:
       - Reset Glitch Hack (RGH): 'Hacks/Reset_Glitch_Hack.md'


### PR DESCRIPTION
* Replaces all mentions of the OFTC and EFnet channels with the \#free60 Libera.Chat channel.
* Adds a page with a link to the Discord guild.
* The front page now links to the IRC and Discord channels.

Hopefully having active channels will encourage better contributions to the project and wiki.